### PR TITLE
docs: update build steps for project publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ cd win11-advanced-timer
 ```powershell
 dotnet restore src/AdvancedTimer.sln
 ```
-3. Build the solution.
+3. Publish the projects.
 ```powershell
-dotnet build src/AdvancedTimer.sln --configuration Release
+dotnet publish src/AdvancedTimer.App/AdvancedTimer.App.csproj -c Release -r win10-x64
+dotnet publish src/AdvancedTimer.WidgetProvider/AdvancedTimer.WidgetProvider.csproj -c Release -r win10-x64
 ```
 4. Create the MSIX package.
 ```powershell


### PR DESCRIPTION
## Summary
- document publishing for app and widget provider projects separately
- retain msix packaging instructions

## Testing
- `dotnet publish src/AdvancedTimer.App/AdvancedTimer.App.csproj -c Release -r win10-x64` *(fails: XamlCompiler.exe Exec format error)*
- `dotnet publish src/AdvancedTimer.WidgetProvider/AdvancedTimer.WidgetProvider.csproj -c Release -r win10-x64` *(fails: UpdateWidget method overload error)*

------
https://chatgpt.com/codex/tasks/task_e_68b455a3a6b48330b9d9149e06e0906c