### PR TITLE
Use unified duration param for timer widgets

### DIFF
--- a/src/AdvancedTimer.WidgetProvider/WidgetProvider.cs
+++ b/src/AdvancedTimer.WidgetProvider/WidgetProvider.cs
@@ -89,8 +89,8 @@ public sealed class WidgetProvider : IWidgetProvider
         switch (args.Verb)
         {
             case "startPreset":
-            case "startCustom":
             case "restartRecent":
+            {
                 TimeSpan dur = TimeSpan.Zero;
                 string? name = null;
                 if (root.TryGetProperty("durationSeconds", out var durProp) && durProp.TryGetInt32(out var secs))
@@ -106,6 +106,29 @@ public sealed class WidgetProvider : IWidgetProvider
                     _service.Start(dur, name, wid);
                 }
                 break;
+            }
+            case "startCustom":
+            {
+                TimeSpan dur = TimeSpan.Zero;
+                string? name = null;
+                if (root.TryGetProperty("minutes", out var minProp) && minProp.TryGetInt32(out var mins))
+                {
+                    dur += TimeSpan.FromMinutes(mins);
+                }
+                if (root.TryGetProperty("seconds", out var secProp) && secProp.TryGetInt32(out var secs))
+                {
+                    dur += TimeSpan.FromSeconds(secs);
+                }
+                if (root.TryGetProperty("name", out var nameProp))
+                {
+                    name = nameProp.GetString();
+                }
+                if (dur > TimeSpan.Zero)
+                {
+                    _service.Start(dur, name, wid);
+                }
+                break;
+            }
             case "pause":
                 if (TryGetId(root, out var idp))
                 {

--- a/src/Widgets/Timer.Large.json
+++ b/src/Widgets/Timer.Large.json
@@ -47,19 +47,19 @@
           "type": "Action.Execute",
           "title": "1 min",
           "verb": "startPreset",
-          "data": { "seconds": 60 }
+          "data": { "durationSeconds": 60 }
         },
         {
           "type": "Action.Execute",
           "title": "5 min",
           "verb": "startPreset",
-          "data": { "seconds": 300 }
+          "data": { "durationSeconds": 300 }
         },
         {
           "type": "Action.Execute",
           "title": "10 min",
           "verb": "startPreset",
-          "data": { "seconds": 600 }
+          "data": { "durationSeconds": 600 }
         }
       ]
     },
@@ -118,7 +118,7 @@
                       "type": "Action.Execute",
                       "title": "Restart",
                       "verb": "restartRecent",
-                      "data": { "seconds": 60 }
+                      "data": { "durationSeconds": 60 }
                     }
                   ]
                 }
@@ -142,7 +142,7 @@
                       "type": "Action.Execute",
                       "title": "Restart",
                       "verb": "restartRecent",
-                      "data": { "seconds": 300 }
+                      "data": { "durationSeconds": 300 }
                     }
                   ]
                 }

--- a/src/Widgets/Timer.Medium.json
+++ b/src/Widgets/Timer.Medium.json
@@ -47,19 +47,19 @@
           "type": "Action.Execute",
           "title": "1 min",
           "verb": "startPreset",
-          "data": { "seconds": 60 }
+          "data": { "durationSeconds": 60 }
         },
         {
           "type": "Action.Execute",
           "title": "5 min",
           "verb": "startPreset",
-          "data": { "seconds": 300 }
+          "data": { "durationSeconds": 300 }
         },
         {
           "type": "Action.Execute",
           "title": "10 min",
           "verb": "startPreset",
-          "data": { "seconds": 600 }
+          "data": { "durationSeconds": 600 }
         }
       ]
     },
@@ -118,7 +118,7 @@
                       "type": "Action.Execute",
                       "title": "Restart",
                       "verb": "restartRecent",
-                      "data": { "seconds": 60 }
+                      "data": { "durationSeconds": 60 }
                     }
                   ]
                 }
@@ -142,7 +142,7 @@
                       "type": "Action.Execute",
                       "title": "Restart",
                       "verb": "restartRecent",
-                      "data": { "seconds": 300 }
+                      "data": { "durationSeconds": 300 }
                     }
                   ]
                 }

--- a/src/Widgets/Timer.Small.json
+++ b/src/Widgets/Timer.Small.json
@@ -47,19 +47,19 @@
           "type": "Action.Execute",
           "title": "1 min",
           "verb": "startPreset",
-          "data": { "seconds": 60 }
+          "data": { "durationSeconds": 60 }
         },
         {
           "type": "Action.Execute",
           "title": "5 min",
           "verb": "startPreset",
-          "data": { "seconds": 300 }
+          "data": { "durationSeconds": 300 }
         },
         {
           "type": "Action.Execute",
           "title": "10 min",
           "verb": "startPreset",
-          "data": { "seconds": 600 }
+          "data": { "durationSeconds": 600 }
         }
       ]
     },
@@ -118,7 +118,7 @@
                       "type": "Action.Execute",
                       "title": "Restart",
                       "verb": "restartRecent",
-                      "data": { "seconds": 60 }
+                      "data": { "durationSeconds": 60 }
                     }
                   ]
                 }
@@ -142,7 +142,7 @@
                       "type": "Action.Execute",
                       "title": "Restart",
                       "verb": "restartRecent",
-                      "data": { "seconds": 300 }
+                      "data": { "durationSeconds": 300 }
                     }
                   ]
                 }


### PR DESCRIPTION
## Summary
- send `durationSeconds` for preset and recent timer widget actions
- parse `minutes` and `seconds` for custom timer starts

## Testing
- `dotnet build src/AdvancedTimer.sln` *(fails: XamlCompiler.exe exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68b458e8cf00833089b04bf868658e0c