### PR TITLE
Template timer widgets with data binding

### DIFF
--- a/src/Widgets/Timer.Large.json
+++ b/src/Widgets/Timer.Large.json
@@ -5,13 +5,13 @@
   "body": [
     {
       "type": "TextBlock",
-      "text": "Timer",
+      "text": "${activeName}",
       "weight": "Bolder",
       "size": "Medium"
     },
     {
       "type": "TextBlock",
-      "text": "00:00",
+      "text": "${remainingText}",
       "horizontalAlignment": "Center",
       "size": "ExtraLarge"
     },
@@ -103,10 +103,11 @@
       ],
       "rows": [
         {
+          "$data": "${data.recents}",
           "cells": [
             {
               "type": "TableCell",
-              "items": [ { "type": "TextBlock", "text": "1 min" } ]
+              "items": [ { "type": "TextBlock", "text": "${name}" } ]
             },
             {
               "type": "TableCell",
@@ -118,31 +119,7 @@
                       "type": "Action.Execute",
                       "title": "Restart",
                       "verb": "restartRecent",
-                      "data": { "durationSeconds": 60 }
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "cells": [
-            {
-              "type": "TableCell",
-              "items": [ { "type": "TextBlock", "text": "5 min" } ]
-            },
-            {
-              "type": "TableCell",
-              "items": [
-                {
-                  "type": "ActionSet",
-                  "actions": [
-                    {
-                      "type": "Action.Execute",
-                      "title": "Restart",
-                      "verb": "restartRecent",
-                      "data": { "durationSeconds": 300 }
+                      "data": { "durationSeconds": "${durationSeconds}" }
                     }
                   ]
                 }

--- a/src/Widgets/Timer.Medium.json
+++ b/src/Widgets/Timer.Medium.json
@@ -5,13 +5,13 @@
   "body": [
     {
       "type": "TextBlock",
-      "text": "Timer",
+      "text": "${activeName}",
       "weight": "Bolder",
       "size": "Medium"
     },
     {
       "type": "TextBlock",
-      "text": "00:00",
+      "text": "${remainingText}",
       "horizontalAlignment": "Center",
       "size": "ExtraLarge"
     },
@@ -103,10 +103,11 @@
       ],
       "rows": [
         {
+          "$data": "${data.recents}",
           "cells": [
             {
               "type": "TableCell",
-              "items": [ { "type": "TextBlock", "text": "1 min" } ]
+              "items": [ { "type": "TextBlock", "text": "${name}" } ]
             },
             {
               "type": "TableCell",
@@ -118,31 +119,7 @@
                       "type": "Action.Execute",
                       "title": "Restart",
                       "verb": "restartRecent",
-                      "data": { "durationSeconds": 60 }
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "cells": [
-            {
-              "type": "TableCell",
-              "items": [ { "type": "TextBlock", "text": "5 min" } ]
-            },
-            {
-              "type": "TableCell",
-              "items": [
-                {
-                  "type": "ActionSet",
-                  "actions": [
-                    {
-                      "type": "Action.Execute",
-                      "title": "Restart",
-                      "verb": "restartRecent",
-                      "data": { "durationSeconds": 300 }
+                      "data": { "durationSeconds": "${durationSeconds}" }
                     }
                   ]
                 }

--- a/src/Widgets/Timer.Small.json
+++ b/src/Widgets/Timer.Small.json
@@ -5,13 +5,13 @@
   "body": [
     {
       "type": "TextBlock",
-      "text": "Timer",
+      "text": "${activeName}",
       "weight": "Bolder",
       "size": "Medium"
     },
     {
       "type": "TextBlock",
-      "text": "00:00",
+      "text": "${remainingText}",
       "horizontalAlignment": "Center",
       "size": "ExtraLarge"
     },
@@ -103,10 +103,11 @@
       ],
       "rows": [
         {
+          "$data": "${data.recents}",
           "cells": [
             {
               "type": "TableCell",
-              "items": [ { "type": "TextBlock", "text": "1 min" } ]
+              "items": [ { "type": "TextBlock", "text": "${name}" } ]
             },
             {
               "type": "TableCell",
@@ -118,31 +119,7 @@
                       "type": "Action.Execute",
                       "title": "Restart",
                       "verb": "restartRecent",
-                      "data": { "durationSeconds": 60 }
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "cells": [
-            {
-              "type": "TableCell",
-              "items": [ { "type": "TextBlock", "text": "5 min" } ]
-            },
-            {
-              "type": "TableCell",
-              "items": [
-                {
-                  "type": "ActionSet",
-                  "actions": [
-                    {
-                      "type": "Action.Execute",
-                      "title": "Restart",
-                      "verb": "restartRecent",
-                      "data": { "durationSeconds": 300 }
+                      "data": { "durationSeconds": "${durationSeconds}" }
                     }
                   ]
                 }


### PR DESCRIPTION
## Summary
- use data bindings for active timer name and remaining time
- render recents table from `data.recents`

## Testing
- `python3 -m json.tool src/Widgets/Timer.Large.json`
- `python3 -m json.tool src/Widgets/Timer.Medium.json`
- `python3 -m json.tool src/Widgets/Timer.Small.json`
- `npx ajv-cli validate -s adaptive-card-schema.json -d src/Widgets/Timer.Large.json` *(fails: NOT SUPPORTED keyword "id")*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b45aadb3ac8330a1c659db59f15f15