### PR TITLE
Support HUD protocol for timer display

### DIFF
--- a/src/AdvancedTimer.App/Program.cs
+++ b/src/AdvancedTimer.App/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using AdvancedTimer.Core;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
@@ -52,6 +53,18 @@ public partial class Program
                     if (item != null)
                     {
                         NotificationHelper.ScheduleToast(item);
+                    }
+                }
+            }
+            else if (uri.Host.Equals("hud", StringComparison.OrdinalIgnoreCase))
+            {
+                var id = GetTimerIdFromUri(uri);
+                if (id != null)
+                {
+                    var item = _timerService?.GetAllActive().FirstOrDefault(t => t.Id == id.Value);
+                    if (item != null)
+                    {
+                        App.ShowTimer(item);
                     }
                 }
             }

--- a/src/AdvancedTimer.WidgetProvider/WidgetProvider.cs
+++ b/src/AdvancedTimer.WidgetProvider/WidgetProvider.cs
@@ -152,7 +152,7 @@ public sealed class WidgetProvider : IWidgetProvider
                 {
                     try
                     {
-                        Process.Start(new ProcessStartInfo($"advancedtimer://restart?timerId={idh}") { UseShellExecute = true });
+                        Process.Start(new ProcessStartInfo($"advancedtimer://hud?timerId={idh}") { UseShellExecute = true });
                     }
                     catch { }
                 }


### PR DESCRIPTION
## Summary
- handle `advancedtimer://hud?timerId=<id>` protocol to show existing timer without restarting
- update widget provider to launch HUD protocol for `openHud`

## Testing
- `dotnet build src/AdvancedTimer.sln` *(fails: XamlCompiler exec format error and UpdateWidget signature mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b45f58ef588330a18edf38f64823e7