### PR TITLE
Schedule toast notifications after starting timers

### DIFF
--- a/src/AdvancedTimer.WidgetProvider/AdvancedTimer.WidgetProvider.csproj
+++ b/src/AdvancedTimer.WidgetProvider/AdvancedTimer.WidgetProvider.csproj
@@ -10,5 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../AdvancedTimer.Core/AdvancedTimer.Core.csproj" />
+    <ProjectReference Include="../AdvancedTimer.App/AdvancedTimer.App.csproj" />
   </ItemGroup>
 </Project>

--- a/src/AdvancedTimer.WidgetProvider/WidgetProvider.cs
+++ b/src/AdvancedTimer.WidgetProvider/WidgetProvider.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using AdvancedTimer.Core;
+using AdvancedTimer.App;
 using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Providers;
 
@@ -103,7 +104,8 @@ public sealed class WidgetProvider : IWidgetProvider
                 }
                 if (dur > TimeSpan.Zero)
                 {
-                    _service.Start(dur, name, wid);
+                    var item = _service.Start(dur, name, wid);
+                    NotificationHelper.ScheduleToast(item);
                 }
                 break;
             }
@@ -125,7 +127,8 @@ public sealed class WidgetProvider : IWidgetProvider
                 }
                 if (dur > TimeSpan.Zero)
                 {
-                    _service.Start(dur, name, wid);
+                    var item = _service.Start(dur, name, wid);
+                    NotificationHelper.ScheduleToast(item);
                 }
                 break;
             }


### PR DESCRIPTION
## Summary
- schedule toast notifications after starting timers in WidgetProvider
- reference app project to access NotificationHelper

## Testing
- `dotnet build src/AdvancedTimer.sln` *(fails: /root/.nuget/packages/.../XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68b4602b42fc8330906bc64c9a50e6d9