### PR TITLE
Add toast scheduling flag to TimerHudWindow

### DIFF
--- a/src/AdvancedTimer.App/App.cs
+++ b/src/AdvancedTimer.App/App.cs
@@ -10,9 +10,9 @@ public partial class App : Application
         // Application entry point. Timers are shown on demand.
     }
 
-    public static void ShowTimer(TimerItem item)
+    public static void ShowTimer(TimerItem item, bool scheduleToast = true)
     {
-        var window = new TimerHudWindow(Program.TimerService, item);
+        var window = new TimerHudWindow(Program.TimerService, item, scheduleToast);
         window.Activate();
     }
 }

--- a/src/AdvancedTimer.App/Program.cs
+++ b/src/AdvancedTimer.App/Program.cs
@@ -64,7 +64,7 @@ public partial class Program
                     var item = _timerService?.GetAllActive().FirstOrDefault(t => t.Id == id.Value);
                     if (item != null)
                     {
-                        App.ShowTimer(item);
+                        App.ShowTimer(item, false);
                     }
                 }
             }

--- a/src/AdvancedTimer.App/TimerHudWindow.xaml.cs
+++ b/src/AdvancedTimer.App/TimerHudWindow.xaml.cs
@@ -14,12 +14,13 @@ public sealed partial class TimerHudWindow : Window
     private readonly Guid _timerId;
     private DispatcherTimer? _dispatcher;
 
-    public TimerHudWindow(TimerService service, TimerItem item)
+    public TimerHudWindow(TimerService service, TimerItem item, bool scheduleToast = true)
     {
         this.InitializeComponent();
         _service = service;
         _timerId = item.Id;
-        NotificationHelper.ScheduleToast(item);
+        if (scheduleToast)
+            NotificationHelper.ScheduleToast(item);
 
         _dispatcher = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
         _dispatcher.Tick += OnTick;


### PR DESCRIPTION
## Summary
- allow `TimerHudWindow` to skip toast scheduling
- enable `App.ShowTimer` to forward scheduling flag
- avoid rescheduling when handling `advancedtimer://hud`

## Testing
- `dotnet build src/AdvancedTimer.sln` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68b48b8520848330abe9bac6ada1b727