### PR TITLE
Include names with recent timer restarts

### DIFF
--- a/src/AdvancedTimer.WidgetProvider/WidgetProvider.cs
+++ b/src/AdvancedTimer.WidgetProvider/WidgetProvider.cs
@@ -198,7 +198,11 @@ public sealed class WidgetProvider : IWidgetProvider
         string template = File.Exists(templatePath) ? File.ReadAllText(templatePath) : "{}";
 
         var active = Guid.TryParse(context.Id, out var wid) ? _service.GetActiveForWidget(wid) : null;
-        var recents = _service.GetRecents();
+        var recents = _service.GetRecents().Select(r => new
+        {
+            name = r.Name,
+            durationSeconds = (int)r.Duration.TotalSeconds
+        });
 
         var data = new
         {

--- a/src/Widgets/Timer.Large.json
+++ b/src/Widgets/Timer.Large.json
@@ -122,7 +122,7 @@
                       "type": "Action.Execute",
                       "title": "Restart",
                       "verb": "restartRecent",
-                      "data": { "durationSeconds": "${durationSeconds}" }
+                      "data": { "name": "${name}", "durationSeconds": ${durationSeconds} }
                     }
                   ]
                 }

--- a/src/Widgets/Timer.Medium.json
+++ b/src/Widgets/Timer.Medium.json
@@ -122,7 +122,7 @@
                       "type": "Action.Execute",
                       "title": "Restart",
                       "verb": "restartRecent",
-                      "data": { "durationSeconds": "${durationSeconds}" }
+                      "data": { "name": "${name}", "durationSeconds": ${durationSeconds} }
                     }
                   ]
                 }

--- a/src/Widgets/Timer.Small.json
+++ b/src/Widgets/Timer.Small.json
@@ -122,7 +122,7 @@
                       "type": "Action.Execute",
                       "title": "Restart",
                       "verb": "restartRecent",
-                      "data": { "durationSeconds": "${durationSeconds}" }
+                      "data": { "name": "${name}", "durationSeconds": ${durationSeconds} }
                     }
                   ]
                 }


### PR DESCRIPTION
## Summary
- project recents to include name and numeric duration
- pass name and numeric duration when restarting recent timers

## Testing
- `dotnet build src/AdvancedTimer.sln -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68b487b547fc833091bec24398525eb8