### PR TITLE
Enable nullable reference types in TimerService

### DIFF
--- a/src/AdvancedTimer.Core/TimerService.cs
+++ b/src/AdvancedTimer.Core/TimerService.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,11 +22,11 @@ public class TimerService
 
     public TimerItem Start(TimeSpan duration, string? name = null, Guid? widgetId = null)
     {
-        name = string.IsNullOrWhiteSpace(name) ? GenerateName() : name;
+        var resolvedName = string.IsNullOrWhiteSpace(name) ? GenerateName() : name;
         var now = DateTimeOffset.UtcNow;
-        var item = new TimerItem(Guid.NewGuid(), name, duration, duration, now, false, widgetId);
+        var item = new TimerItem(Guid.NewGuid(), resolvedName, duration, duration, now, false, widgetId);
         _state.ActiveTimers.Add(item);
-        AddRecent(name, duration);
+        AddRecent(resolvedName, duration);
         Save();
         return item;
     }


### PR DESCRIPTION
## Summary
- enable nullable reference types in `TimerService`
- ensure timer names are non-null by using `resolvedName`

## Testing
- `dotnet build src/AdvancedTimer.sln` *(fails: XamlCompiler.exe: Exec format error)*
- `dotnet build src/AdvancedTimer.Core/AdvancedTimer.Core.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b49b060bec8330b6a699f44f2c669f