### PR TITLE
Document release build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,15 @@ cd win11-advanced-timer
 ```powershell
 dotnet restore src/AdvancedTimer.sln
 ```
-3. (Optional) Produce RID-specific outputs. Note that `dotnet publish` is required for both `AdvancedTimer.App` and `AdvancedTimer.WidgetProvider` when targeting a specific runtime identifier; otherwise the build is handled during MSIX packaging.
+3. Publish the app.
 ```powershell
-dotnet publish src/AdvancedTimer.App/AdvancedTimer.App.csproj -c Release -r <RID>
-dotnet publish src/AdvancedTimer.WidgetProvider/AdvancedTimer.WidgetProvider.csproj -c Release -r <RID>
+dotnet publish src/AdvancedTimer.App/AdvancedTimer.App.csproj -c Release -r win10-x64 --self-contained
 ```
-4. Create the MSIX package.
+4. Publish the widget provider.
+```powershell
+dotnet publish src/AdvancedTimer.WidgetProvider/AdvancedTimer.WidgetProvider.csproj -c Release -r win10-x64 --self-contained
+```
+5. Create the MSIX package.
 ```powershell
 msbuild src/AdvancedTimer.App/AdvancedTimer.App.csproj `
     /p:Configuration=Release `


### PR DESCRIPTION
## Summary
- clarify release build instructions in README

## Testing
- `dotnet restore src/AdvancedTimer.sln`
- `dotnet build src/AdvancedTimer.sln -c Release` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ac6ca210833099ca1184030cc38e