### PR TITLE
Use recents binding in timer templates

### DIFF
--- a/src/Widgets/Timer.Large.json
+++ b/src/Widgets/Timer.Large.json
@@ -106,7 +106,7 @@
       ],
       "rows": [
         {
-          "$data": "${data.recents}",
+          "$data": "${recents}",
           "cells": [
             {
               "type": "TableCell",

--- a/src/Widgets/Timer.Medium.json
+++ b/src/Widgets/Timer.Medium.json
@@ -106,7 +106,7 @@
       ],
       "rows": [
         {
-          "$data": "${data.recents}",
+          "$data": "${recents}",
           "cells": [
             {
               "type": "TableCell",

--- a/src/Widgets/Timer.Small.json
+++ b/src/Widgets/Timer.Small.json
@@ -106,7 +106,7 @@
       ],
       "rows": [
         {
-          "$data": "${data.recents}",
+          "$data": "${recents}",
           "cells": [
             {
               "type": "TableCell",


### PR DESCRIPTION
## Summary
- use `${recents}` for table data in timer templates
- ensure recent restart includes name and numeric duration
- verify timer actions still send active id

## Testing
- `dotnet build src/AdvancedTimer.sln` *(fails: Microsoft.UI.Xaml.Markup.Compiler requires Windows)*

------
https://chatgpt.com/codex/tasks/task_e_68b59ab4058c833094b5f303f82bc3e1